### PR TITLE
Open wallet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
-	"plugins/blockchain"
+	"plugins/blockchain",
+	"plugins/wallet",
 ]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: valor_bin default clean build_plugins pack
 
-PLUGINS=blockchain
+PLUGINS=blockchain wallet
 OUT_DIR=.build
 NATIVE_PLUGINS=$(PLUGINS:%=${OUT_DIR}/plugins/%)
 CODEDEPLOY_FILES=$(shell find -L .codedeploy -type f)

--- a/plugins.json
+++ b/plugins.json
@@ -1,1 +1,4 @@
-[{"type":"native","name":"blockchain", "prefix": "_vln"}]
+[
+	{"type":"native","name":"blockchain", "prefix": "_vln"},
+	{"type":"native","name":"wallet"}
+]

--- a/plugins/wallet/Cargo.toml
+++ b/plugins/wallet/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wallet"
+version = "0.1.0"
+authors = ["Daniel Olano <daniel@olanod.com>"]
+edition = "2018"
+
+[dependencies]
+path-tree = "0.1.12"
+valor = { version = "0.4.7-beta.0", package = "valor_core", features = ["util"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+valor = { version = "0.4.7-beta.0", package = "valor_core", features = ["util", "web"] }
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/plugins/wallet/src/lib.rs
+++ b/plugins/wallet/src/lib.rs
@@ -1,0 +1,45 @@
+use path_tree::PathTree;
+use valor::*;
+
+enum Cmd {
+    Open,
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[vlugin]
+async fn wallet(req: Request) -> Response {
+    let routes = {
+        let mut p = PathTree::new();
+        p.insert("/open", Cmd::Open);
+        p
+    };
+    let url = req.url();
+    let action = routes.find(url.path());
+    if action.is_none() {
+        return StatusCode::NotFound.into();
+    }
+    let (action, _params) = action.unwrap();
+
+    match (req.method(), action) {
+        (Method::Get, Cmd::Open) => open_wallet().await,
+        _ => Ok(StatusCode::MethodNotAllowed.into()),
+    }
+    .unwrap_or_else(Into::into)
+}
+
+async fn open_wallet() -> Result<Response> {
+    todo!()
+}
+
+pub enum Error {
+    Unknown,
+}
+
+impl From<Error> for Response {
+    fn from(e: Error) -> Self {
+        match e {
+            _ => StatusCode::InternalServerError.into(),
+        }
+    }
+}


### PR DESCRIPTION
This PR tackles BAC-3682(#13) which allows a caller generate a session token used that represents an "open wallet". The holder of this token would be able to sign transactions until the token expires.