### PR TITLE
feat: friendly tx-id

### DIFF
--- a/plugins/blockchain/Cargo.toml
+++ b/plugins/blockchain/Cargo.toml
@@ -13,6 +13,7 @@ hex = "0.4.2"
 jsonrpc = { version = "0.12.0", default-features = false }
 once_cell = "1.5.2"
 parity-scale-codec = "1.3.6"
+http-client = "6.3.0"
 path-tree = "0.1.12"
 surf = { version = "2.1.0", default-features = false, features = ["h1-client"] }
 twox-hash = { version = "1.6.0", default-features = false }

--- a/plugins/blockchain/Cargo.toml
+++ b/plugins/blockchain/Cargo.toml
@@ -18,6 +18,7 @@ path-tree = "0.1.12"
 surf = { version = "2.1.0", default-features = false, features = ["h1-client"] }
 twox-hash = { version = "1.6.0", default-features = false }
 valor = { version = "0.4.7-beta.0", package = "valor_core", features = ["util"] }
+bs58 = "0.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 valor = { version = "0.4.7-beta.0", package = "valor_core", features = ["util", "web"] }

--- a/plugins/blockchain/src/util_hash.rs
+++ b/plugins/blockchain/src/util_hash.rs
@@ -1,5 +1,5 @@
 use blake2::{Blake2b, Digest};
-use bs58::encode;
+use bs58;
 use core::hash::Hasher;
 use frame_metadata::StorageHasher;
 

--- a/plugins/blockchain/src/util_hash.rs
+++ b/plugins/blockchain/src/util_hash.rs
@@ -1,4 +1,5 @@
 use blake2::{Blake2b, Digest};
+use bs58::encode;
 use core::hash::Hasher;
 use frame_metadata::StorageHasher;
 
@@ -53,4 +54,25 @@ fn twox_hash(input: &[u8]) -> Vec<u8> {
     LittleEndian::write_u64(&mut dest[8..16], r1);
 
     dest.into()
+}
+
+/// Gives a short friendly transaction-id
+/// Encode the first 32bits to base58
+fn get_short_tx_id(input: &str) -> Vec<u8> {
+    let input = if input.starts_with("0x") {
+        hex::decode(&input[2..]).unwrap_or_else(|_| input.into())
+    } else {
+        input.into()
+    };
+    bs58::encode(&input[0..4]).into_vec()
+}
+
+#[test]
+fn get_short_tx_id_works() {
+    let result =
+        get_short_tx_id("0xd7bd44af293e45e0dc7583d12c6e75492410b3d74b01fe87371dc2eea1637a57");
+    assert_eq!("6WquqG".as_bytes().to_vec(), result);
+
+    let result_2 = get_short_tx_id("0xed5ad5f258eef6a9745042bde7d46e8a5254c183");
+    assert_eq!("74taQq".as_bytes().to_vec(), result_2);
 }


### PR DESCRIPTION
Resolve #7

- Util function to generate a user friendly tx-id. Encode first 32bits of given transaction-id using base58.
- added `http-client` to `Cargo.toml` to fix build error