### PR TITLE
fix:run deploy only on push

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,7 @@ jobs:
 
   publish:
     name: Publish codedeploy archive
+    if: ${{ github.event_name == 'push' }}
     runs-on: self-hosted
     needs: build
     steps:


### PR DESCRIPTION
Resolves #21

Link to doc : https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsif